### PR TITLE
Issue #19: Fix for intermittent failing #random test in generator spec

### DIFF
--- a/spec/cryptozoologist/generator_spec.rb
+++ b/spec/cryptozoologist/generator_spec.rb
@@ -28,7 +28,11 @@ describe Cryptozoologist do
     end
 
     describe('with quantity') do
+      let(:test_quantity_library) { ["quantity"] }
+
       before do
+        allow(Cryptozoologist::Dictionary).to receive(:send).and_call_original
+        allow(Cryptozoologist::Dictionary).to receive(:send).with(:quantity).and_return(test_quantity_library)
         Cryptozoologist.configure do |config|
           config.include = [:quantity]
           config.delimiter = "_"
@@ -41,7 +45,6 @@ describe Cryptozoologist do
       end
 
       it 'only has one word from the quantity list' do
-        Cryptozoologist.random
         random = Cryptozoologist.random.split("_")
         matches = Cryptozoologist::Dictionaries::Quantity.list.select do |word|
           random.include?(word)


### PR DESCRIPTION
I decided to stub out the quantity library in order to ensure that the scenario that causes the intermittent failure will no longer occur. With this fix, it is assured that the random string generated will always have one word from the quantity list.

I also deleted an unnecessary `Cryptozoologist.random` from the test. 

Other fixes I considered and am happy to implement instead if they seem a better fix than this one:
- deleting the test entirely - because the test above this one ensures that there is a word from the quantity library in the string generated, I wasn't sure that this test was entirely necessary. Also, `sample` is used without any arguments, so it will always return one object from the library - I'm not sure that needs testing. But I decided it would be better to leave test coverage as is. 

- deleting `asian giant hornet` from the common animals dictionary. This might fix the current issue, but if there were other items in other dictionaries that had a quantity word in their name, it wouldn't stop similar intermittent failures from happening in the future.

- change the code so that when a string is generated a check is done to ensure that the words used only appear in one dictionary. For this issue it seemed a better idea to just deal with the test itself, but this is an option that could be considered for the future.

Please let me know if you would like to discuss anything or if you have a different idea for the fix that you would prefer to see. Thanks!