### PR TITLE
Adding Rubocop ruby linter

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,25 @@
+# Built-in config:
+# https://github.com/bbatsov/rubocop/blob/master/config/default.yml
+
+Documentation:
+  Enabled: false
+
+# We'll enforce one style eventually, but not yet
+StringLiterals:
+  Enabled: false
+
+# this is for ruby 3 upgrade happiness. Not yet.
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+# Run rails specific checks
+# https://github.com/bbatsov/rubocop#rails
+Rails:
+  Enabled: false
+
+Metrics/LineLength:
+  Max: 120
+
+Style/FileName:
+  Exclude:
+    - Gemfile

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,14 @@ If you'd like to suggest a new feature, create a new issue using the [new featur
 
 Encountered a bug? Oh no! File a bug report using the [bug report template](ISSUE_TEMPLATES/bug_report.md).
 
+## Code style
+
+Crytozoologist uses Rubocop to ensure the ruby code follows a consistent style. This is checked by codeclimate whenyou contribute a pull request on github. You can check the style yourself by running rubocop
+```
+bundle exec rubocop
+```
+
+
 ## Releasing
 
 I try and release the gem fairly regularly when I add features. Whatever is on master is generally what's available in the most recent version release!

--- a/cryptozoologist.gemspec
+++ b/cryptozoologist.gemspec
@@ -24,4 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.4"
   spec.add_development_dependency "pry", "~> 0.10.3"
   spec.add_development_dependency "pry-nav", "~> 0.2.4"
+
+  spec.add_development_dependency "rubocop", "0.49.1"
 end


### PR DESCRIPTION
i saw you have code climate enabled, but have a really low score at the moment
https://codeclimate.com/github/feministy/cryptozoologist


this adds rubocop, which can then be used to lint the code and then we can gradually make the small improvements to make the code climate score better (more readable code, less repetition etc)

